### PR TITLE
Fix inaccurate figures and repair 10 dead reference links

### DIFF
--- a/src/content/docs/cooperative-commons.md
+++ b/src/content/docs/cooperative-commons.md
@@ -130,9 +130,10 @@ Explore how cooperative economics already shows up in your community:
 ## References
 
 - Mondragon Worker Cooperative Federation: https://www.mondragon-corporation.com/en
-- Ostrom's Eight Principles for Governing Commons: https://www.environmentalscience.org/ostrom-principles-commons
-- Gitcoin Grants (quadratic funding examples): https://gitcoin.co/grants
+- Ostrom's Eight Principles for Governing Commons: https://www.onthecommons.org/magazine/elinor-ostroms-8-principles-managing-commmons/
+- Gitcoin Grants (quadratic funding examples): https://grants.gitcoin.co
 - Greenpill Network: https://greenpill.network
-- Kenya Coffee Cooperatives overview: https://www.coffeevboardkenya.co.ke
+- Coffee Directorate, Agriculture and Food Authority of Kenya (the body that now oversees the coffee cooperatives): https://www.afa.go.ke
 - International Cooperative Alliance: https://www.ica.coop/en
-- Community Currencies in Practice (global examples): https://communitycurrencies.net
+- International Journal of Community Currency Research (peer-reviewed studies of community currencies worldwide): https://ijccr.net
+- Complementary Currency Resource Center (global directory and software): https://complementarycurrency.org

--- a/src/content/docs/daos-vs-traditional.md
+++ b/src/content/docs/daos-vs-traditional.md
@@ -65,7 +65,7 @@ DAOs flip the script. Instead of centralized control, decision-making is distrib
 
 Think of it like a cooperative where everyone who participates can own a share. When you acquire a DAO's token, you gain a voice in how it operates. Major decisions, how to spend funds, what projects to pursue, are put to a vote. Anyone with a token can participate.
 
-As of 2022, over 215 DAOs collectively managed around $9.5 billion with approximately 500,000 active members. They're building protocols, funding public goods, and experimenting with new forms of coordination.
+Thousands of DAOs now operate across the major chains, collectively holding treasuries in the tens of billions of dollars. They're building protocols, funding public goods, and experimenting with new forms of coordination. The headline totals move fast and the trackers that publish them come and go, so treat any specific figure you read as a snapshot rather than a fixed fact, and check its date.
 
 ---
 

--- a/src/content/docs/decentralization-resilience.md
+++ b/src/content/docs/decentralization-resilience.md
@@ -100,7 +100,7 @@ Based on these insights, regenerative communities can embrace several core princ
 - Ethereum.org, What is Decentralization?
   https://ethereum.org/en/web3/
 - Greenpill Local, Community Infrastructure and Regeneration
-  https://greenpill.live/
+  https://greenpill.network/
 - RadicalxChange, Quadratic Funding and Localist Governance
   https://radicalxchange.org/
 - Crisis Preparedness and Response, Community Resilience Resources

--- a/src/content/docs/documentation-knowledge.md
+++ b/src/content/docs/documentation-knowledge.md
@@ -310,10 +310,10 @@ Write for someone who has never been to your community before. What is obvious t
 ## References
 
 - Greenpill Local, Community Building and Knowledge Management
-  https://greenpill.live/
+  https://greenpill.network/
 - Notion, Getting Started with Documentation
   https://www.notion.so/
 - GitBook, Documentation Best Practices
   https://www.gitbook.com/
 - Ethereum Foundation, DAO Governance Documentation
-  https://ethereum.org/en/web3/social-networks/#daos
+  https://ethereum.org/en/dao/

--- a/src/content/docs/hot-vs-cold.md
+++ b/src/content/docs/hot-vs-cold.md
@@ -119,4 +119,4 @@ Audit your current crypto setup, even if you only hold a small amount:
 - Ledger hardware wallets: https://shop.ledger.com
 - Trezor hardware wallets: https://trezor.io
 - Safe (formerly Gnosis Safe) multi-signature wallet: https://safe.global
-- Cryptocurrency Security Standards (for deeper security practices): https://cryptocurrencysecuritystandard.org
+- Cryptocurrency Security Standards (for deeper security practices): https://cryptoconsortium.org/standards/CCSS

--- a/src/content/docs/leadership-development.md
+++ b/src/content/docs/leadership-development.md
@@ -296,7 +296,7 @@ Do this twice a year. Your community becomes less fragile every time.
 - Heifetz, Ronald, and Marty Linsky. *Leadership on the Line: Staying Alive Through the Dangers of Leading*. Harvard Business Review Press, 2002.
 - Stone, Douglas, and Bruce Patton. *Difficult Conversations: How to Discuss What Matters Most*. Penguin, 2000.
 - ICA:UK. "Facilitative Leadership." ica-uk.co.uk
-- Greenpill Local. "Distributed Leadership in Practice." greenpill.live
+- Greenpill Local. "Distributed Leadership in Practice." https://greenpill.network
 
 ---
 

--- a/src/content/docs/nfts-beyond-art.md
+++ b/src/content/docs/nfts-beyond-art.md
@@ -147,5 +147,5 @@ If an NFT-based version of that record would solve a real problem for your commu
 - Axie Infinity: https://axieinfinity.com
 - Decentraland: https://decentraland.org
 - IBM Food Trust: https://www.ibm.com/blockchain/solutions/food-trust
-- Kings of Leon NFT album: https://kingsonleonxyz
-- Bankless, NFT utility explainer: https://newsletter.bankless.com
+- Kings of Leon, *When You See Yourself*, the first album released as an NFT: https://en.wikipedia.org/wiki/When_You_See_Yourself
+- Bankless, NFT utility explainer: https://www.bankless.com/read

--- a/src/content/docs/tokens-coordination-tools.md
+++ b/src/content/docs/tokens-coordination-tools.md
@@ -104,7 +104,7 @@ Visit Snapshot (snapshot.org) and look at a few active proposals from a DAO that
 - SuperBenefit Knowledge Garden, Anticapture Framework: https://knowledge.superbenefit.org
 - MakerDAO Governance Portal: https://makerdao.com
 - Gitcoin, Quadratic Funding: https://gitcoin.co
-- KlimaDAO: https://klima DAO.com
+- KlimaDAO: https://klimadao.finance
 - Colony, Reputation-Based Governance: https://colony.io
 - Tally, On-Chain Governance: https://tally.xyz
 - Snapshot, Off-Chain Voting: https://snapshot.org

--- a/src/content/docs/what-are-tokens.md
+++ b/src/content/docs/what-are-tokens.md
@@ -144,4 +144,4 @@ The technology is still evolving, and there are legitimate concerns about volati
 - Ledger Academy for crypto education: ledger.com/academy
 - Carbonmark carbon credit platform: carbonmark.com
 - Puro.earth and carbon removal: puro.earth
-- KlimaDAO and carbon markets: klimaDAO.com
+- KlimaDAO and carbon markets: https://klimadao.finance

--- a/src/content/docs/what-is-cryptocurrency.md
+++ b/src/content/docs/what-is-cryptocurrency.md
@@ -37,7 +37,7 @@ Tokens are the part most relevant to community work, because they behave like th
 
 The honest answer to "why should I care?": you almost certainly don't *need* crypto, and be suspicious of anyone who says you do. But a few real projects show where it genuinely helps the kind of work you do.
 
-**Local currencies that survive a cash drought.** Grassroots Economics in Kenya runs the **Sarafu Network**, a community currency that lets neighbours trade goods and labour when national cash is scarce. As of early 2026 it reports supporting roughly 26,000 people across some 290 communities, and it now runs on a low-energy blockchain called Celo. It's a digital version of the mutual credit that's powered communities for centuries.
+**Local currencies that survive a cash drought.** Grassroots Economics in Kenya runs the **Sarafu Network**, a community currency that lets neighbours trade goods and labour when national cash is scarce. It reports supporting more than 26,600 people across 290+ communities, and it now runs on a low-energy blockchain called Celo. It's a digital version of the mutual credit that's powered communities for centuries.
 
 **Paying growers directly, without the middle layers.** **Regen Network** lets land stewards register regenerative projects and issue ecological credits for measured outcomes like soil carbon, then sell them to buyers. It connects the people doing the work to the people funding it, instead of routing through several layers of brokers who each take a cut.
 
@@ -47,7 +47,7 @@ The honest answer to "why should I care?": you almost certainly don't *need* cry
 
 ## Addressing the Fears Head-On
 
-**"Isn't this terrible for the planet?"** It depends entirely on *which* blockchain. Bitcoin still uses **proof of work**, a system that secures the network by burning electricity, and it consumes roughly as much power each year as a small country like Norway. But in 2022 Ethereum switched to **proof of stake**, which secures the network without the energy race, and cut its electricity use by about 99.95% overnight. Most newer chains work this way, including Celo, the one the projects above use. "Crypto wrecks the climate" was largely a Bitcoin story. Judge each project by the chain it runs on.
+**"Isn't this terrible for the planet?"** It depends entirely on *which* blockchain. Bitcoin still uses **proof of work**, a system that secures the network by burning electricity. The Cambridge Centre for Alternative Finance put its consumption at about 138 terawatt-hours a year in its April 2025 study, roughly 0.5% of global electricity use, or about what a country the size of Norway gets through. But in 2022 Ethereum switched to **proof of stake**, which secures the network without the energy race, and cut its electricity use by about 99.95% overnight. Most newer chains work this way, including Celo, the one the projects above use. "Crypto wrecks the climate" was largely a Bitcoin story. Judge each project by the chain it runs on.
 
 **"Won't I get scammed or look foolish?"** Scams are real, and healthy caution is exactly the right instinct. The rule that protects you is simple: a legitimate project never pressures you, never promises guaranteed returns, and never needs your secret key or recovery phrase. Anyone who asks for those is robbing you. You can learn how all of this works without ever spending a penny.
 
@@ -65,7 +65,8 @@ The honest answer to "why should I care?": you almost certainly don't *need* cry
 
 - [Kaspersky: What Is Cryptocurrency?](https://www.kaspersky.com/resource-center/definitions/what-is-cryptocurrency): plain definition of cryptocurrency, cryptography, and how digital money differs from cash.
 - [Ethereum.org: The Merge](https://ethereum.org/roadmap/merge/): the official account of Ethereum's 2022 switch to proof of stake and the ~99.95% energy reduction.
-- [Cambridge Bitcoin Electricity Consumption Index](https://ccaf.io/cbnsi/cbeci/comparisons): independent estimates of Bitcoin's energy use, with country comparisons.
+- [Cambridge Bitcoin Electricity Consumption Index](https://ccaf.io/cbnsi/cbeci/comparisons): independent estimates of Bitcoin's energy use, with country comparisons. The live index moves with the network's hashrate, so expect it to differ from the dated study figure above.
+- [Cambridge study: sustainable energy rising in Bitcoin mining](https://www.jbs.cam.ac.uk/2025/cambridge-study-sustainable-energy-rising-in-bitcoin-mining/): the April 2025 Digital Mining Industry Report. Source of the 138 TWh and 0.5%-of-global figures, and of the finding that 52.4% of mining now runs on sustainable sources.
 - [Grassroots Economics: Sarafu Network](https://www.grassrootseconomics.org/sarafu-network): the Kenyan community-currency project, its scale, and its move onto a low-energy blockchain.
 - [Regen Network](https://www.regen.network/): ecological credits and a marketplace that connects land stewards to funders.
 - [Glo Dollar: How It Works](https://www.glodollar.org/articles/how-glo-dollar-works): a nonprofit stablecoin that donates its reserve interest to causes its holders choose.

--- a/src/content/docs/what-is-ethereum.md
+++ b/src/content/docs/what-is-ethereum.md
@@ -119,7 +119,7 @@ Here are real possibilities for regenerative communities:
 - Ethereum.org, Smart Contracts
   https://ethereum.org/en/developers/docs/smart-contracts/
 - Ethereum.org, DAOs
-  https://ethereum.org/en/web3/social-networks/#daos
+  https://ethereum.org/en/dao/
 - MetaMask, Getting Started with Ethereum
   https://metamask.io/
 - Ethereum Name Service

--- a/src/content/docs/what-web3-can-cant-do.md
+++ b/src/content/docs/what-web3-can-cant-do.md
@@ -17,7 +17,7 @@ Think of it like choosing between a community seed library and a bank vault. The
 
 You can send money or digital tokens to anyone, anywhere, at any hour, without a bank or a service like Western Union deciding whether you are allowed. A **token** is just a digital unit of value recorded on a blockchain, the way a poker chip stands in for cash at a table.
 
-This is not theoretical. **Grassroots Economics**, a Kenyan nonprofit, runs **Sarafu**, a community currency that over 50,000 people have used to trade food, goods, and services in places where regular cash and banking are scarce. It works on basic phones over USSD (the same dial-a-code menus used for mobile money like M-Pesa), and the transaction record lives on a public blockchain so the community, not a bank, governs it. For mutual-aid networks and local economies, that is a real capability that ordinary banking cannot match.
+This is not theoretical. **Grassroots Economics**, a Kenyan nonprofit, runs **Sarafu**, a community currency that has supported more than 26,600 people across 290+ communities to trade food, goods, and services in places where regular cash and banking are scarce. It works on basic phones over USSD (the same dial-a-code menus used for mobile money like M-Pesa), and the transaction record lives on a public blockchain so the community, not a bank, governs it. For mutual-aid networks and local economies, that is a real capability that ordinary banking cannot match.
 
 ### It lets anyone build without asking permission
 
@@ -82,7 +82,8 @@ You don't have to be for or against Web3. You just have to match the tool to the
 
 ## References
 
-- [Grassroots Economics: Sarafu Network](https://www.grassrootseconomics.org/sarafu-network) - The Kenyan community-currency project, showing real blockchain use for local economies.
+- [Grassroots Economics: Sarafu Network](https://www.grassrootseconomics.org/sarafu-network) - The Kenyan community-currency project, showing real blockchain use for local economies. Source of the 26,600+ people and 290+ communities figures.
+- [Sarafu Community Inclusion Currency 2020-2021](https://www.nature.com/articles/s41597-022-01539-4) - Peer-reviewed dataset in *Scientific Data*. Registered accounts grew from 8,354 to around 55,000 between January 2020 and June 2021. Note that this counts accounts over that period, not people supported today.
 - [ethereum.org: Scaling](https://ethereum.org/developers/docs/scaling/) - Plain explanation of Layer 2 networks and why they exist.
 - [Toucan: Response to Verra's announcement](https://blog.toucan.earth/response-to-verras-announcement/) - Toucan's own account of Verra's May 2022 decision to halt tokenisation of retired carbon credits, a clear case of on-chain code meeting off-chain rules.
 - [ethereum.org: Oracles](https://ethereum.org/developers/docs/oracles/) - What oracles are and why the "trust the bridge to the real world" problem is hard.

--- a/src/content/docs/why-accept-crypto.md
+++ b/src/content/docs/why-accept-crypto.md
@@ -115,6 +115,6 @@ Start small and learn as you go:
 - Endaoment nonprofit crypto donation processor: https://endaoment.org
 - Every.org free crypto donation option: https://every.org/crypto
 - Givepact crypto giving platform: https://givepact.com
-- Gitcoin Grants quadratic funding rounds: https://gitcoin.co/grants
+- Gitcoin Grants quadratic funding rounds: https://grants.gitcoin.co
 - Fidelity Charitable on crypto donations (tax guidance): https://www.fidelitycharitable.org
 - IRS guidance on cryptocurrency donations: https://www.irs.gov/pub/irs-drop/n-14-21.pdf


### PR DESCRIPTION
Content-only pass. Touches nothing outside `src/content/docs/`.

## Accuracy

Each figure checked against a primary source.

**Sarafu** (`what-web3-can-cant-do.md`) claimed "over 50,000 people". The page's own References section cites [grassrootseconomics.org/sarafu-network](https://www.grassrootseconomics.org/sarafu-network), which states "26,600+ People Supported". The claim contradicted its own citation. Separately, `what-is-cryptocurrency.md` had already been corrected to ~26,000, so the two pages disagreed with each other. Both now say 26,600+ across 290+ communities. Added the peer-reviewed [Scientific Data dataset](https://www.nature.com/articles/s41597-022-01539-4) as a second reference for historical scale, framed as registered accounts (~55,000, Jan 2020 to Jun 2021) rather than people, since those count different things.

**Bitcoin energy** (`what-is-cryptocurrency.md`). The existing "small country like Norway" comparison was unsourced but turns out to be sound, so it stays. Cambridge CCAF's April 2025 Digital Mining Industry Report puts Bitcoin at 138 TWh/year, about 0.5% of global electricity. Norway used 128.8 TWh in 2024. Added the figure, the date and the citation so the claim ages transparently.

**DAO scale** (`daos-vs-traditional.md`) said "As of 2022, over 215 DAOs ... $9.5 billion ... 500,000 active members", four years stale. DeepDAO, the primary source for such aggregates, no longer resolves, and current numbers are only available via SEO content farms. Rewritten directionally with a caution to check the date on any figure, rather than substituting an unverifiable number.

## Dead links

All 385 external links swept. 10 were dead; every replacement returns HTTP 200.

Two were malformed in the source itself:

- `https://klima DAO.com` contained a literal space
- `https://kingsonleonxyz` had no dots at all

Hosts that no longer resolve: `greenpill.live` (3 files), `newsletter.bankless.com`, `communitycurrencies.net`, `cryptocurrencysecuritystandard.org`, `coffeevboardkenya.co.ke`.

404s: `gitcoin.co/grants` (2 files), `ethereum.org/en/web3/social-networks/#daos` (2 files), the environmentalscience.org Ostrom page.

The 21 HTTP 403s are Cloudflare blocking automated requests rather than dead pages, so they were left alone.

## Supersedes #312

#312 attempts the same two figure fixes. Its Bitcoin change is wrong: it sets the comparison to Poland at "140 to 170 TWh" and attributes that to the Cambridge Centre for Alternative Finance. Cambridge published 138 TWh and never published that range, and Poland used 159.7 to 171.3 TWh against Bitcoin's 138, so the original Norway comparison was the more accurate one. #312 should be closed rather than merged.

Site builds clean at 124 pages.
